### PR TITLE
Add timestamp and transaction timestamp fields to output

### DIFF
--- a/suietl/domain/checkpoint.py
+++ b/suietl/domain/checkpoint.py
@@ -32,5 +32,6 @@ class SuiCheckpoint(object):
         self.previous_digest = None
         self.sequence_number = None
         self.timestamp_ms = None
+        self.timestamp = None
         self.transactions = []
         self.validator_signature = None

--- a/suietl/domain/transaction.py
+++ b/suietl/domain/transaction.py
@@ -30,5 +30,6 @@ class SuiTransaction(object):
         self.gas_data = {}
         self.object_changes = []
         self.timestamp_ms = None
+        self.timestamp = None
         self.transaction = None
         self.tx_signatures = []

--- a/suietl/domain/transaction_block_effects.py
+++ b/suietl/domain/transaction_block_effects.py
@@ -26,6 +26,7 @@ class SuiTransactionBlockEffects(object):
         self.checkpoint_number = None
         self.transaction_digest = None
         self.timestamp_ms = None
+        self.transaction_timestamp = None
         self.status = None
         self.executed_epoch = None
         self.gas_used = None

--- a/suietl/domain/transaction_block_event.py
+++ b/suietl/domain/transaction_block_event.py
@@ -26,6 +26,7 @@ class SuiTransactionBlockEvent(object):
         self.checkpoint_number = None
         self.transaction_digest = None
         self.timestamp_ms = None
+        self.transaction_timestamp = None
         self.id = None
         self.package_id = None
         self.transaction_module = None

--- a/suietl/mappers/checkpoint_mapper.py
+++ b/suietl/mappers/checkpoint_mapper.py
@@ -22,6 +22,7 @@
 
 
 from suietl.domain.checkpoint import SuiCheckpoint
+from suietl.utils import epoch_milliseconds_to_rfc3339
 from ethereumetl.utils import to_int_or_none
 
 
@@ -47,6 +48,7 @@ class SuiCheckpointMapper(object):
         checkpoint.previous_digest = json_dict.get("previousDigest")
         checkpoint.sequence_number = to_int_or_none(json_dict.get("sequenceNumber"))
         checkpoint.timestamp_ms = to_int_or_none(json_dict.get("timestampMs"))
+        checkpoint.timestamp = epoch_milliseconds_to_rfc3339(checkpoint.timestamp_ms)
         checkpoint.transactions = json_dict.get("transactions")
         checkpoint.validator_signature = json_dict.get("validatorSignature")
 
@@ -98,6 +100,7 @@ class SuiCheckpointMapper(object):
             "previous_digest": checkpoint.previous_digest,
             "sequence_number": checkpoint.sequence_number,
             "timestamp_ms": checkpoint.timestamp_ms,
+            "timestamp": checkpoint.timestamp,
             "transactions": checkpoint.transactions,
             "validator_signature": checkpoint.validator_signature,
         }

--- a/suietl/mappers/transaction_block_effects_mapper.py
+++ b/suietl/mappers/transaction_block_effects_mapper.py
@@ -22,6 +22,7 @@
 
 
 from suietl.domain.transaction_block_effects import SuiTransactionBlockEffects
+from suietl.utils import epoch_milliseconds_to_rfc3339
 from ethereumetl.utils import to_int_or_none
 
 
@@ -31,6 +32,7 @@ class SuiTransactionBlockEffectsMapper(object):
         effects.checkpoint_number = to_int_or_none(json_dict.get("checkpoint"))
         effects.transaction_digest = json_dict.get("digest")
         effects.timestamp_ms = to_int_or_none(json_dict.get("timestampMs"))
+        effects.transaction_timestamp = epoch_milliseconds_to_rfc3339(effects.timestamp_ms)
 
         json_effects_dict = json_dict.get("effects")
         effects.status = json_effects_dict.get("status")
@@ -131,6 +133,7 @@ class SuiTransactionBlockEffectsMapper(object):
             "checkpoint_number": effects.checkpoint_number,
             "transaction_digest": effects.transaction_digest,
             "timestamp_ms": effects.timestamp_ms,
+            "transaction_timestamp": effects.transaction_timestamp,
             "status": effects.status,
             "executed_epoch": effects.executed_epoch,
             "gas_used": effects.gas_used,

--- a/suietl/mappers/transaction_block_events_mapper.py
+++ b/suietl/mappers/transaction_block_events_mapper.py
@@ -22,6 +22,7 @@
 
 
 from suietl.domain.transaction_block_event import SuiTransactionBlockEvent
+from suietl.utils import epoch_milliseconds_to_rfc3339
 from ethereumetl.utils import to_int_or_none
 
 
@@ -30,6 +31,7 @@ class SuiTransactionBlockEventsMapper(object):
         checkpoint_number = to_int_or_none(json_dict.get("checkpoint"))
         transaction_digest = json_dict.get("digest")
         timestamp_ms = to_int_or_none(json_dict.get("timestampMs"))
+        transaction_timestamp = epoch_milliseconds_to_rfc3339(timestamp_ms)
 
         json_events_dict = json_dict.get("events", [])
         events = []
@@ -38,6 +40,7 @@ class SuiTransactionBlockEventsMapper(object):
             event.checkpoint_number = checkpoint_number
             event.transaction_digest = transaction_digest
             event.timestamp_ms = timestamp_ms
+            event.transaction_timestamp = transaction_timestamp
             event.id = self.parse_event_id(json_event_dict.get("id"))
             event.package_id = json_event_dict.get("packageId")
             event.transaction_module = json_event_dict.get("transactionModule")
@@ -69,6 +72,7 @@ class SuiTransactionBlockEventsMapper(object):
             "checkpoint_number": event.checkpoint_number,
             "transaction_digest": event.transaction_digest,
             "timestamp_ms": event.timestamp_ms,
+            "transaction_timestamp": event.transaction_timestamp,
             "id": event.id,
             "package_id": event.package_id,
             "transaction_module": event.transaction_module,

--- a/suietl/mappers/transaction_mapper.py
+++ b/suietl/mappers/transaction_mapper.py
@@ -22,6 +22,7 @@
 
 
 from suietl.domain.transaction import SuiTransaction
+from suietl.utils import epoch_milliseconds_to_rfc3339
 from ethereumetl.utils import to_int_or_none
 
 
@@ -31,6 +32,7 @@ class SuiTransactionMapper(object):
         transaction.checkpoint_number = to_int_or_none(json_dict.get("checkpoint"))
         transaction.digest = json_dict.get("digest")
         transaction.timestamp_ms = to_int_or_none(json_dict.get("timestampMs"))
+        transaction.timestamp = epoch_milliseconds_to_rfc3339(transaction.timestamp_ms)
         transaction.balance_changes = self.parse_balance_changes(json_dict.get("balanceChanges", []))
         transaction.object_changes = self.parse_object_changes(json_dict.get("objectChanges", []))
 
@@ -159,6 +161,7 @@ class SuiTransactionMapper(object):
             "sender": transaction.sender,
             "gas_data": transaction.gas_data,
             "timestamp_ms": transaction.timestamp_ms,
+            "timestamp": transaction.timestamp,
             "transaction": transaction.transaction,
             "tx_signatures": transaction.tx_signatures,
             "balance_changes": transaction.balance_changes,

--- a/suietl/streaming/sui_item_timestamp_calculator.py
+++ b/suietl/streaming/sui_item_timestamp_calculator.py
@@ -29,15 +29,14 @@ class SuiItemTimestampCalculator:
     def calculate(self, item):
         if item is None or not isinstance(item, dict):
             return None
+        
+        item_type = item.get('type')
 
-        if item.get('timestamp_ms') is not None:
-            return epoch_milliseconds_to_rfc3339(item.get('timestamp_ms'))
+        if item_type in ('checkpoint', 'transaction')  and item.get('timestamp') is not None:
+            return item.get('timestamp')
+        elif item.get('transaction_timestamp') is not None:
+            return item.get('transaction_timestamp')
 
         logging.warning('item_timestamp for item {} is None'.format(json.dumps(item)))
 
         return None
-
-
-def epoch_milliseconds_to_rfc3339(timestamp):
-    t = timestamp / 1000.0
-    return datetime.utcfromtimestamp(int(t)).isoformat() + 'Z'

--- a/suietl/utils.py
+++ b/suietl/utils.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 
+from datetime import datetime
 import itertools
 import warnings
 
@@ -153,3 +154,8 @@ def check_classic_provider_uri(chain, provider_uri):
         )
         return "https://ethereumclassic.network"
     return provider_uri
+
+
+def epoch_milliseconds_to_rfc3339(timestamp):
+    t = timestamp / 1000.0
+    return datetime.utcfromtimestamp(int(t)).isoformat() + 'Z'


### PR DESCRIPTION
To be somewhat similar to ethereum etl, timestamp fields are now renamed to `timestamp` for checkpoints and transactions and to `transaction_timestamp` for effects and events.

Here is an example of output after running it locally with the changes.
```
{"type": "checkpoint", "checkpoint_commitments": [], "end_of_epoch_data": null, "digest": "EmZCXQk8wrCYTWS621Yvtz7YRhCARa9gS7jzfEodq7uS", "epoch": 0, "epoch_rolling_gas_cost_summary": {"computation_cost": 0, "storage_cost": 0, "storage_rebate": 0, "non_refundable_storage_fee": null}, "network_total_transactions": 8157, "previous_digest": "4VH6XgWEgAEKQnwpeMAbnjY342mPFs8ZSKip53zhBK6e", "sequence_number": 8156, "timestamp_ms": 1681403096500, "timestamp": "2023-04-13T16:24:56Z", "transactions": ["5Yc9GBnBKrGsTtZw6Xo6TkEauDC5XAxQEYqpWT3WRbeK"], "validator_signature": "kp3IuZ1FyCwUwLsiafupxI+AlkzC0tX00sEqlzoBCyfoadLAH2KOxzbgWzWWGNW4", "item_id": "checkpoint_EmZCXQk8wrCYTWS621Yvtz7YRhCARa9gS7jzfEodq7uS", "item_timestamp": "2023-04-13T16:24:56Z"}
{"type": "transaction", "checkpoint_number": 8156, "digest": "5Yc9GBnBKrGsTtZw6Xo6TkEauDC5XAxQEYqpWT3WRbeK", "sender": "0x0000000000000000000000000000000000000000000000000000000000000000", "gas_data": {"payment": [{"object_id": "0x0000000000000000000000000000000000000000000000000000000000000000", "version": 0, "digest": "11111111111111111111111111111111"}], "owner": "0x0000000000000000000000000000000000000000000000000000000000000000", "price": 1, "budget": 0}, "timestamp_ms": 1681403096500, "timestamp": "2023-04-13T16:24:56Z", "transaction": "{'kind': 'ConsensusCommitPrologue', 'epoch': '0', 'round': '18318', 'commit_timestamp_ms': '1681403096500'}", "tx_signatures": ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="], "balance_changes": [], "object_changes": {"mutated": [{"sender": "0x0000000000000000000000000000000000000000000000000000000000000000", "owner": null, "object_type": "0x2::clock::Clock", "object_id": "0x0000000000000000000000000000000000000000000000000000000000000006", "version": "8157", "previous_version": "8156", "digest": "BRJyKhEd5SK9deo9PSdGrzbPxktWJbtsTaxRKN3wqiCT"}]}, "item_id": "transaction_5Yc9GBnBKrGsTtZw6Xo6TkEauDC5XAxQEYqpWT3WRbeK", "item_timestamp": "2023-04-13T16:24:56Z"}
{"type": "effect", "checkpoint_number": 8156, "transaction_digest": "5Yc9GBnBKrGsTtZw6Xo6TkEauDC5XAxQEYqpWT3WRbeK", "timestamp_ms": 1681403096500, "transaction_timestamp": "2023-04-13T16:24:56Z", "status": {"status": "success"}, "executed_epoch": 0, "gas_used": {"computation_cost": 0, "storage_cost": 0, "storage_rebate": 0, "non_refundable_storage_fee": 0}, "modified_at_versions": [{"object_id": "0x0000000000000000000000000000000000000000000000000000000000000006", "sequence_number": "8156"}], "shared_objects": [{"object_id": "0x0000000000000000000000000000000000000000000000000000000000000006", "sequence_number": null, "digest": "H3BzCS1gZB6YWvQNqnZUmSmENcR13Qgru6dNCMiajjJ2"}], "created": [], "mutated": [{"owner": {"address_owner": null, "object_owner": null, "shared": {"initial_shared_version": 1}}, "reference": {"object_id": "0x0000000000000000000000000000000000000000000000000000000000000006", "version": 8157, "digest": "BRJyKhEd5SK9deo9PSdGrzbPxktWJbtsTaxRKN3wqiCT"}}], "unwrapped": [], "deleted": [], "unwrapped_then_deleted": [], "wrapped": [], "gas_object": {"owner": {"address_owner": "0x0000000000000000000000000000000000000000000000000000000000000000", "object_owner": null, "shared": null}, "reference": {"object_id": "0x0000000000000000000000000000000000000000000000000000000000000000", "version": 0, "digest": "11111111111111111111111111111111"}}, "events_digest": null, "dependencies": ["9GdCFHGHVoKYbqVjB3rozzWxmn7KhNaHj5hAvcH2Jx6f"], "item_id": "effect_5Yc9GBnBKrGsTtZw6Xo6TkEauDC5XAxQEYqpWT3WRbeK", "item_timestamp": "2023-04-13T16:24:56Z"}
```